### PR TITLE
Expand core models and add serialization tests

### DIFF
--- a/docs/developer_manual.md
+++ b/docs/developer_manual.md
@@ -1,0 +1,133 @@
+# CC Framework Research & Development Guide
+
+This manual gives engineers a complete overview of the `cc-framework`, how its
+components interact, and concrete steps for extending and validating the
+system.  It is intended as a living document; feel free to submit pull requests
+that refine or extend the material.
+
+## 1. Architectural Overview
+
+### 1.1 Core Packages
+
+| Package | Responsibility |
+|---------|----------------|
+| `cc.core` | Dataclasses, metrics, protocol orchestration, and logging utilities. |
+| `cc.guardrails` | Defensive components such as keyword filters and model wrappers. |
+| `cc.analysis` | Statistical routines for compositional capabilities (CC) evaluation. |
+| `cc.io` | Data loading, experiment persistence, and serialization helpers. |
+| `cc.examples` | Small runnable scripts demonstrating framework features. |
+| `cc._legacy` | Historical reference implementations kept for comparison. |
+
+### 1.2 Data Flow
+
+1. **Experiment configuration** is loaded or constructed with
+   `ExperimentConfig`.
+2. **Attack sessions** are executed, yielding `AttackResult` objects.
+3. **Guardrail stacks** alter behaviour according to `GuardrailSpec` entries in
+   each `WorldConfig`.
+4. **Metrics** consume serialized results (`AttackResult.to_dict()`) and output
+   `CCResult` summaries.
+5. **Analyses** persist artefacts via `cc.io` for reproducibility.
+
+### 1.3 Directory Structure
+
+```
+src/cc
+├── core          # models, metrics, and protocol helpers
+├── guardrails    # built‑in guardrail implementations
+├── analysis      # statistical evaluation routines
+├── io            # dataset and serialization utilities
+└── _legacy       # reference implementations
+```
+
+## 2. Getting Started
+
+### 2.1 Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+```
+
+### 2.2 Running the Test Suite
+
+```bash
+PYTHONPATH=src pytest tests/unit
+```
+
+### 2.3 Quick Example
+
+```python
+from cc.core.models import ExperimentConfig, GuardrailSpec
+
+config = ExperimentConfig(
+    experiment_id="demo",
+    n_sessions=10,
+    attack_strategies=["baseline"],
+    guardrail_configs={
+        "world0": [GuardrailSpec(name="keyword", params={"terms": ["ban"]})],
+    },
+)
+print(config.to_dict())
+```
+
+## 3. Key Research Questions
+
+1. How can guardrail stacking reduce attack success while maintaining utility?
+2. Which statistical estimators yield the most stable CC measurements under
+   limited samples?
+3. What attacker strategy diversity is necessary to confidently bound CC?
+4. How do different environment hashes influence reproducibility across runs?
+5. Can adaptive guardrails learn from failed defences without leaking data?
+
+## 4. Technical Improvement Suggestions
+
+- **Type Safety** – introduce `mypy` and `ruff` to enforce style and typing.
+- **Configuration Validation** – migrate dataclasses to `pydantic` models for
+  automatic validation and schema export.
+- **Experiment Tracking** – integrate an experiment tracker (e.g. MLflow) to
+  centralize metrics and artefacts.
+- **Parallel Simulation** – leverage `asyncio` or multiprocessing to speed up
+  large attack sweeps.
+- **Reproducibility** – record package versions and environment hashes in every
+  result payload.
+
+## 5. Implementation & Extension Guidelines
+
+### 5.1 Adding a New Guardrail
+
+1. Implement a class under `cc.guardrails` exposing a `score(text)` method.
+2. Provide a calibration routine returning empirical FPRs.
+3. Define a `GuardrailSpec` describing parameters and versioning.
+4. Register the guardrail in the chosen `WorldConfig` guardrail stack.
+
+```python
+@dataclass
+class LengthGuardrail:
+    max_tokens: int
+
+    def score(self, text: str) -> float:
+        return 1.0 if len(text.split()) > self.max_tokens else 0.0
+```
+
+### 5.2 Creating an Attack Strategy
+
+1. Add a new subclass under `cc.core.attackers` implementing a `generate` method.
+2. Register its name and default parameters in experiment configuration files.
+3. Provide unit tests that validate `to_dict` serialization of the new strategy.
+
+### 5.3 Contributing Analyses
+
+1. Place new statistical routines in `cc.analysis` with clear docstrings.
+2. Accept and return `AttackResult`/`CCResult` dataclasses for consistency.
+3. Write benchmarks under `examples/` demonstrating usage and performance.
+
+## 6. Action Items
+
+- [ ] Integrate static analysis and linting (`mypy`, `ruff`).
+- [ ] Document attack strategy schemas in the `docs/` directory.
+- [ ] Provide examples for multi-guardrail experimentation.
+- [ ] Benchmark alternative bootstrapping methods for CC estimation.
+- [ ] Add CI workflows executing tests and style checks on pull requests.
+

--- a/src/cc/core/models.py
+++ b/src/cc/core/models.py
@@ -1,12 +1,11 @@
-# src/cc/core/models.py
-"""
-Core data models for CC framework
-"""
+"""Core data models for the CC framework."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
 
 
 @dataclass
@@ -25,8 +24,8 @@ class AttackResult:
     utility_score: Optional[float] = None
 
     def to_dict(self) -> Dict[str, Any]:
-        """Convert to dictionary for serialization"""
-        return {k: v for k, v in self.__dict__.items() if v is not None}
+        """Convert to a serializable dictionary including all fields."""
+        return asdict(self)
 
 
 @dataclass
@@ -43,6 +42,10 @@ class GuardrailSpec:
         if not self.params:
             self.params = {}
 
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to a serializable dictionary including all fields."""
+        return asdict(self)
+
 
 @dataclass
 class WorldConfig:
@@ -53,3 +56,61 @@ class WorldConfig:
     utility_profile: Dict[str, Any]
     env_hash: str = ""
     baseline_success_rate: float = 0.6
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to a serializable dictionary including all fields."""
+        return asdict(self)
+
+
+@dataclass
+class ExperimentConfig:
+    """Complete experiment configuration."""
+
+    experiment_id: str
+    n_sessions: int
+    attack_strategies: List[str]
+    guardrail_configs: Dict[str, List[GuardrailSpec]]
+    utility_target: float = 0.9
+    utility_tolerance: float = 0.02
+    random_seed: int = 42
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to a serializable dictionary including all fields."""
+        return asdict(self)
+
+
+@dataclass
+class CCResult:
+    """Results of CC analysis."""
+
+    j_empirical: float
+    cc_max: float
+    delta_add: float
+    cc_multiplicative: Optional[float] = None
+    confidence_interval: Optional[Tuple[float, float]] = None
+    bootstrap_samples: Optional[np.ndarray] = None
+    n_sessions: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to a serializable dictionary including all fields."""
+        data: Dict[str, Any] = asdict(self)
+        if data["bootstrap_samples"] is not None:
+            data["bootstrap_samples"] = data["bootstrap_samples"].tolist()
+        if data["confidence_interval"] is not None:
+            data["confidence_interval"] = list(data["confidence_interval"])
+        return data
+
+
+@dataclass
+class AttackStrategy:
+    """Configuration for attack strategy."""
+
+    name: str
+    params: Dict[str, Any]
+    vocabulary: List[str] = field(default_factory=list)
+    success_threshold: float = 0.5
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to a serializable dictionary including all fields."""
+        return asdict(self)
+

--- a/tests/unit/test_models_serialization.py
+++ b/tests/unit/test_models_serialization.py
@@ -1,0 +1,80 @@
+import numpy as np
+
+from cc.core.models import (
+    AttackResult,
+    GuardrailSpec,
+    WorldConfig,
+    ExperimentConfig,
+    CCResult,
+    AttackStrategy,
+)
+
+
+def test_attack_result_to_dict_includes_all_fields():
+    result = AttackResult(
+        world_bit=1,
+        success=True,
+        attack_id="a1",
+        transcript_hash="h",
+        guardrails_applied="g",
+        rng_seed=0,
+        timestamp=0.0,
+    )
+    data = result.to_dict()
+    assert set(data.keys()) == set(result.__dataclass_fields__.keys())
+    assert "utility_score" in data and data["utility_score"] is None
+
+
+def test_guardrail_spec_to_dict_includes_all_fields():
+    spec = GuardrailSpec(name="k", params={"p": 1})
+    data = spec.to_dict()
+    assert set(data.keys()) == set(spec.__dataclass_fields__.keys())
+
+
+def test_world_config_to_dict_serializes_nested_spec():
+    spec = GuardrailSpec(name="k", params={})
+    wc = WorldConfig(world_id=0, guardrail_stack=[spec], utility_profile={"u": 1.0})
+    data = wc.to_dict()
+    assert set(data.keys()) == set(wc.__dataclass_fields__.keys())
+    assert isinstance(data["guardrail_stack"][0], dict)
+
+
+def test_experiment_config_to_dict_serializes_nested():
+    spec = GuardrailSpec(name="k", params={})
+    ec = ExperimentConfig(
+        experiment_id="exp",
+        n_sessions=1,
+        attack_strategies=["s"],
+        guardrail_configs={"a": [spec]},
+    )
+    data = ec.to_dict()
+    assert set(data.keys()) == set(ec.__dataclass_fields__.keys())
+    assert isinstance(data["guardrail_configs"]["a"][0], dict)
+
+
+def test_ccresult_to_dict_converts_arrays_and_tuples():
+    arr = np.array([1, 2, 3])
+    cc = CCResult(
+        j_empirical=0.1,
+        cc_max=0.2,
+        delta_add=0.01,
+        cc_multiplicative=0.5,
+        confidence_interval=(0.0, 0.1),
+        bootstrap_samples=arr,
+        n_sessions=10,
+    )
+    data = cc.to_dict()
+    assert set(data.keys()) == set(cc.__dataclass_fields__.keys())
+    assert data["bootstrap_samples"] == [1, 2, 3]
+    assert data["confidence_interval"] == [0.0, 0.1]
+
+
+def test_attack_strategy_to_dict_includes_all_fields():
+    strat = AttackStrategy(
+        name="s",
+        params={"a": 1},
+        vocabulary=["x", "y"],
+        success_threshold=0.7,
+    )
+    data = strat.to_dict()
+    assert set(data.keys()) == set(strat.__dataclass_fields__.keys())


### PR DESCRIPTION
## Summary
- simplify dataclass `to_dict` methods by relying on `dataclasses.asdict` and normalizing numpy arrays for `CCResult`
- greatly expand developer manual with architecture overview, setup steps, extension patterns, and actionable tasks

## Testing
- `PYTHONPATH=src pytest tests/unit/test_models_serialization.py -q`
- `PYTHONPATH=src pytest tests/unit -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb9e95dc808322a77000657bb4d909