### PR TITLE
Implement Bernstein sample size planner

### DIFF
--- a/src/cc/cartographer/planner.py
+++ b/src/cc/cartographer/planner.py
@@ -1,0 +1,82 @@
+"""Sample size planning utilities.
+
+This module houses helpers for determining per-class sample sizes needed to
+control Bernstein tail bounds for class-conditional rates.
+"""
+
+from __future__ import annotations
+
+from math import ceil, log
+from typing import Tuple
+
+from .bounds import fh_var_envelope
+
+__all__ = ["needed_n_bernstein"]
+
+
+def needed_n_bernstein(
+    t: float,
+    D: float,
+    delta: float,
+    I1: Tuple[float, float],
+    I0: Tuple[float, float],
+) -> Tuple[int, int]:
+    """Return sample sizes ensuring Bernstein tails below ``delta``.
+
+    Parameters
+    ----------
+    t : float
+        Target deviation in the performance metric. Must be ``> 0``.
+    D : float
+        Denominator scaling the deviation. Must be ``> 0``.
+    delta : float
+        Total risk budget in ``(0, 1)``.
+    I1, I0 : tuple of float
+        Fréchet–Hoeffding intervals ``[a, b]`` for class-conditional rates.
+
+    Returns
+    -------
+    n1 : int
+        Required sample size for the positive class.
+    n0 : int
+        Required sample size for the negative class.
+
+    Raises
+    ------
+    ValueError
+        If any argument is outside its valid range.
+
+    Notes
+    -----
+    The required ``n_y`` satisfies
+
+    .. math::
+
+        n_y \ge \frac{2 \bar v_y + \frac{2}{3} tD}{(tD)^2}\log\frac{4}{\delta},
+
+    where ``\bar v_y`` is the Fréchet–Hoeffding variance envelope of the
+    corresponding interval.
+    """
+
+    if t <= 0 or D <= 0:
+        raise ValueError("t and D must be > 0.")
+    if not (0 < delta < 1):
+        raise ValueError("delta must be in (0,1).")
+
+    for interval in (I1, I0):
+        a, b = interval
+        if not (0.0 <= a <= b <= 1.0):
+            raise ValueError("intervals must satisfy 0 <= a <= b <= 1.")
+
+    v1 = fh_var_envelope(I1)
+    v0 = fh_var_envelope(I0)
+
+    tD = t * D
+    coeff = log(4.0 / delta)
+
+    def n_req(vbar: float) -> int:
+        num = 2.0 * vbar + (2.0 / 3.0) * tD
+        den = tD**2
+        return max(1, int(ceil((num / den) * coeff)))
+
+    return n_req(v1), n_req(v0)

--- a/tests/unit/test_planner.py
+++ b/tests/unit/test_planner.py
@@ -1,0 +1,48 @@
+"""Unit tests for planner utilities."""
+
+from __future__ import annotations
+
+import pytest
+
+from cc.cartographer.planner import needed_n_bernstein
+
+
+def test_needed_n_bernstein_happy_path() -> None:
+    n1, n0 = needed_n_bernstein(
+        t=0.10,
+        D=0.55,
+        delta=0.05,
+        I1=(0.49, 0.51),
+        I0=(0.04, 0.05),
+    )
+    assert (n1, n0) == (778, 191)
+
+
+def test_needed_n_bernstein_monotonicity() -> None:
+    I1 = (0.49, 0.51)
+    I0 = (0.04, 0.05)
+    base = needed_n_bernstein(0.10, 0.55, 0.05, I1, I0)
+    t_down = needed_n_bernstein(0.05, 0.55, 0.05, I1, I0)
+    assert t_down[0] > base[0] and t_down[1] > base[1]
+    D_down = needed_n_bernstein(0.10, 0.40, 0.05, I1, I0)
+    assert D_down[0] > base[0] and D_down[1] > base[1]
+    delta_down = needed_n_bernstein(0.10, 0.55, 0.01, I1, I0)
+    assert delta_down[0] > base[0] and delta_down[1] > base[1]
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"t": 0.0},
+        {"D": 0.0},
+        {"delta": 0.0},
+        {"delta": 1.0},
+        {"I1": (0.6, 0.5)},
+        {"I0": (0.2, -0.1)},
+    ],
+)
+def test_needed_n_bernstein_invalid_inputs(kwargs: dict) -> None:
+    params = dict(t=0.1, D=0.55, delta=0.05, I1=(0.49, 0.51), I0=(0.04, 0.05))
+    params.update(kwargs)
+    with pytest.raises(ValueError):
+        needed_n_bernstein(**params)


### PR DESCRIPTION
## Summary
- add `needed_n_bernstein` utility for per-class sample size planning
- test planner for correctness, monotonicity, and input validation

## Testing
- `ruff check src/cc/cartographer/planner.py tests/unit/test_planner.py`
- `mypy --follow-imports=skip src/cc/cartographer/planner.py`
- `PYTHONPATH=src pytest tests/unit/test_planner.py -q --cov=src/cc/cartographer/planner.py --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68c489b6ccb88322960f72a107fbfc16