### PR TITLE
Align theory metrics with sampling path

### DIFF
--- a/experiments/correlation_cliff/simulate/core.py
+++ b/experiments/correlation_cliff/simulate/core.py
@@ -248,7 +248,13 @@ def simulate_replicate_at_lambda(
     # Optional: theory reference overlays (separate, explicitly labeled)
     if cfg.include_theory_reference and callable(U.compute_metrics_for_lambda):
         try:
-            theory = U.compute_metrics_for_lambda(cfg.marginals, cfg.rule, lam_f)  # type: ignore[misc]
+            theory = U.compute_metrics_for_lambda(
+                cfg.marginals,
+                cfg.rule,
+                lam_f,
+                path=cfg.path,
+                path_params=cfg.path_params,
+            )  # type: ignore[misc]
             out["CC_theory_ref"] = float(theory.get("CC", float("nan")))
             out["JC_theory_ref"] = float(theory.get("JC", float("nan")))
             out["dC_theory_ref"] = float(theory.get("dC", float("nan")))


### PR DESCRIPTION
### Motivation
- Ensure theory reference overlays use the same dependence path and parameters as sampling so the `*_theory_ref` fields are consistent with how samples are generated.
- Fix a mismatch where `compute_metrics_for_lambda` was called without the configured `path` and `path_params`.

### Description
- Update the call to `U.compute_metrics_for_lambda` inside `simulate_replicate_at_lambda` to pass `path=cfg.path` and `path_params=cfg.path_params`.
- Change implemented as a small multi-line call-site modification in `experiments/correlation_cliff/simulate/core.py`.

### Testing
- No automated tests were run as part of this change.
- No test failures were observed because tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f42ee856c8322bdf71080b65b8af5)