### PR TITLE
Use cluster-robust variance for ATE

### DIFF
--- a/tests/unit/core/test_protocol.py
+++ b/tests/unit/core/test_protocol.py
@@ -1,8 +1,12 @@
 from pathlib import Path
 
+import numpy as np
+from scipy import stats
+
 from cc.core.guardrail_api import GuardrailAdapter
 from cc.core.logging import ChainedJSONLLogger
-from cc.core.protocol import TwoWorldProtocol
+from cc.core.models import AttackResult
+from cc.core.protocol import CausalInferenceEngine, TwoWorldProtocol
 from cc.guardrails.base import Guardrail
 
 
@@ -39,3 +43,55 @@ def test_apply_guardrail_stack_scores_once(tmp_path: Path) -> None:
     assert score == 0.9
     assert triggered == ["CountingGuardrail"]
     assert cg.score_calls == 1
+
+
+def test_causal_effect_cluster_robust_imbalanced_clusters() -> None:
+    rng = np.random.default_rng(4)
+    cluster_sizes = [12, 8, 6, 4]
+    cluster_effects = [0.4, -0.4, 0.4, -0.2]
+    base = 0.4
+    treat = 0.05
+
+    results = []
+    idx = 0
+    for cluster_id, (size, effect) in enumerate(zip(cluster_sizes, cluster_effects)):
+        for i in range(size):
+            world_bit = i % 2
+            p = base + effect + treat * world_bit
+            p = min(max(p, 0.05), 0.95)
+            success = bool(rng.random() < p)
+            results.append(
+                AttackResult(
+                    world_bit=world_bit,
+                    success=success,
+                    attack_id=f"attack-{idx}",
+                    transcript_hash=f"hash-{idx}",
+                    guardrails_applied="none",
+                    rng_seed=idx,
+                    attack_strategy=f"cluster-{cluster_id}",
+                )
+            )
+            idx += 1
+
+    engine = CausalInferenceEngine()
+    effect = engine.estimate_ate(results)
+
+    w0 = [r.success for r in results if r.world_bit == 0]
+    w1 = [r.success for r in results if r.world_bit == 1]
+    p0 = float(np.mean(w0))
+    p1 = float(np.mean(w1))
+    n0 = len(w0)
+    n1 = len(w1)
+    var0 = max(p0 * (1.0 - p0), 1e-12)
+    var1 = max(p1 * (1.0 - p1), 1e-12)
+    naive_se = float(np.sqrt(var0 / n0 + var1 / n1))
+    naive_df = max(min(n0, n1) - 1, 1)
+    naive_ci_half = float(stats.t.ppf(0.975, naive_df)) * naive_se  # type: ignore[arg-type]
+
+    assert (effect.ci_upper - effect.ate) > naive_ci_half
+
+    if naive_se > 0.0:
+        naive_t = effect.ate / naive_se
+        crit = float(stats.t.ppf(0.975, naive_df))  # type: ignore[arg-type]
+        naive_power = float(1.0 - stats.nct.cdf(crit, df=naive_df, nc=abs(naive_t)))  # type: ignore[arg-type]
+        assert effect.power < naive_power


### PR DESCRIPTION
### Motivation
- Avoid underestimating uncertainty from the previous equal-cluster design-effect shortcut by using a cluster-robust variance estimator for the ATE.
- Keep clustering consistent with ICC reporting by reusing the same cluster labels used by `ICCComputer.compute_icc`.
- Fall back to a mixed-effects random-intercept model when clusters are few or highly imbalanced to provide more stable inference.
- Account for unequal cluster sizes in the ICC/design-effect path by incorporating the coefficient of variation (CV) of cluster sizes.

### Description
- Added a `_cluster_labels` helper and changed `ICCComputer.compute_icc` to compute a CV-adjusted design effect `DE = 1 + ICC * (m_bar - 1) * (1 + CV^2)` to reflect unequal cluster sizes.
- Implemented a cluster-robust sandwich estimator `_cluster_robust_ols` and a mixed-effects fallback `_mixedlm_ate` (using `statsmodels`) in `CausalInferenceEngine`, and selected method via `_should_use_mixedlm`.
- Replaced the old ICC-only inflation path in `CausalInferenceEngine.estimate_ate` so `CausalEffect.se`, `ci_lower`, `ci_upper`, and `power` are computed from the cluster-robust or mixed-effects SE and cluster-based degrees of freedom, and the `method` field reflects the estimator used.
- Added unit test `test_causal_effect_cluster_robust_imbalanced_clusters` in `tests/unit/core/test_protocol.py` which generates imbalanced clusters and asserts that the CI is wider and post-hoc power is more conservative than the naive independent assumption.

### Testing
- Added the unit test `tests/unit/core/test_protocol.py::test_causal_effect_cluster_robust_imbalanced_clusters` and committed the changes.
- Attempted to run the unit tests with `pytest -q tests/unit/core/test_protocol.py`, but `pytest` failed due to `pytest-cov` options in `pyproject.toml` requiring the `pytest-cov` plugin (test execution blocked by environment configuration).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fbfb378208322bf2188e0f42c0007)