### PR TITLE
Clarify coverage guidance in audit documentation

### DIFF
--- a/docs/audit/CC-Framework-PhD-Audit.md
+++ b/docs/audit/CC-Framework-PhD-Audit.md
@@ -95,7 +95,8 @@ Integrate into experiments and always report order effects (A→B vs B→A).
 - Add `pyproject.toml` configuring Poetry metadata, dependencies, Black, Ruff, Mypy (strict), Pytest coverage.
 - Add `.pre-commit-config.yaml` hooking Black, Ruff, Mypy.
 - Enforce strict typing + docstrings in NumPy style.
-- Run `pre-commit run --all-files`, `mypy src/ --strict`, `pytest --cov=src/cc --cov-report=html` (target ≥85%).
+- Run `pre-commit run --all-files`, `mypy src/ --strict`, `make test-cov` (target ≥85%).
+- If you run `pytest` directly with `--cov`, ensure `pytest-cov` is installed; otherwise use the coverage-aware Makefile target.
 
 ---
 


### PR DESCRIPTION
### Motivation
- Make the repository guidance for running coverage explicit and CI-friendly so users don't hit failures when `pytest-cov` is not installed.

### Description
- Update `docs/audit/CC-Framework-PhD-Audit.md` to recommend the coverage-aware Makefile target `make test-cov` instead of advising `pytest --cov=src/cc --cov-report=html`, and add a note that running `pytest` with `--cov` requires `pytest-cov` to be installed.

### Testing
- Documentation-only change; no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69678a61f5e4832290cc5c4d369a91ab)