### PR TITLE
ci: add MkDocs config and fix strict docs links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build/
 .coverage
 coverage.*
 htmlcov/
+site/
 
 # results & runs (keep artifacts small)
 results/raw/

--- a/docs/week5_memo.md
+++ b/docs/week5_memo.md
@@ -24,9 +24,7 @@ Table 1 summarises the Week 5 pilot results once the pipeline is executed. Fill 
 
 Figure 1 compares Wilson and bootstrap confidence interval widths, highlighting the guardrail-induced shrinkage after calibration. Figure 2 displays a ROC slice anchored by the calibrated false positive ceiling.
 
-![CI comparison](../figures/week5_ci_comparison.png)
-
-![ROC slice](../figures/week5_roc_slice.png)
+The corresponding Week 5 diagnostic figures are generated artifacts produced by `scripts/make_week5_figs.py` during the pilot pipeline. They are intentionally not required for the strict documentation build.
 
 ## 3. Reflection
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,22 @@
+site_name: CC Framework
+site_description: Composability Coefficient framework documentation
+repo_url: https://github.com/Cubits11/cc-framework
+repo_name: Cubits11/cc-framework
+
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: material
+  features:
+    - navigation.sections
+    - navigation.indexes
+    - content.code.copy
+
+markdown_extensions:
+  - admonition
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.superfences


### PR DESCRIPTION
## Summary

This PR fixes the documentation build infrastructure.

Changes:
- Adds missing `mkdocs.yml`.
- Removes strict-mode broken links to missing generated Week 5 figures.
- Adds `site/` to `.gitignore` so MkDocs build output is not accidentally tracked.

## Validation

- `python -m mkdocs build --strict`
- `git diff --check`

## Non-goals

This PR intentionally does not fix:
- mypy baseline errors
- pytest dependency collection errors
- runtime/test dependency extras
- source-code typing/refactor issues

Those belong to follow-up issues under #55 and later strict-kernel epics.

## Notes

The Week 5 diagnostic figures are generated artifacts produced by `scripts/make_week5_figs.py`. This PR does not create placeholder images or commit generated figures. The docs now build strictly without depending on missing generated research artifacts.